### PR TITLE
Add Mode to `splitFasta` to Split Peptides by FASTA Entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Keep parser compatibility for prior non-circ ORF placement while normalizing serialization to the new canonical order; update `splitFasta`/`summarizeFasta` handling and tests accordingly.
 
+- Add `--split-mode` to `splitFasta` with `peptide` (default) and `entry`; `entry` mode splits multi-entry peptide headers across source-specific tiers instead of forcing a single-tier assignment per peptide sequence.
+
 ## [1.5.1] - 2026-03-02
 
 ### [1.5.1-rc5] - 2026-02-25

--- a/docs/split-fasta.md
+++ b/docs/split-fasta.md
@@ -74,6 +74,13 @@ moPepGen splitFasta \
 
 As a result, `split_gSNP.fasta` and `split_gINDEL.fasta` will be written. `split_gSNP-gINDEL.fasta` and `split_gSNP-RNAEditing.fasta` will also be written although the number of variant sources (2) is larger than the value specified through `--max-source-groups`.
 
+### Split mode
+
+`splitFasta` supports two split modes via `--split-mode`:
+
+- `peptide` (default): each peptide sequence is assigned to only one tier, using source priority.
+- `entry`: each FASTA header entry is assigned independently, so one peptide sequence can appear in multiple tier FASTA files if it has multiple entries with different sources.
+
 ## Arguments
 
 {% with actions=get_arg_data(command) %}

--- a/moPepGen/aa/PeptidePoolSplitter.py
+++ b/moPepGen/aa/PeptidePoolSplitter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from pathlib import Path
 import itertools
+import copy
 from moPepGen.seqvar import GVFMetadata
 from moPepGen import seqvar, circ, constant, VARIANT_PEPTIDE_SOURCE_DELIMITER, \
     SPLIT_DATABASE_KEY_SEPARATER
@@ -153,8 +154,13 @@ class PeptidePoolSplitter():
         return wildcard_map
 
     def split(self, max_groups:int, additional_split:List[Set],
-            tx2gene:Dict[str,str], coding_tx:Set[str]):
+            tx2gene:Dict[str,str], coding_tx:Set[str],
+            split_mode:str='peptide'):
         """ Split peptide pool into separate databases """
+        if split_mode not in {'peptide', 'entry'}:
+            raise ValueError(
+                f"Unsupported split mode: {split_mode}. Use 'peptide' or 'entry'."
+            )
         self.append_order_internal_sources()
         VariantSourceSet.set_levels(self.order)
         delimiter = VARIANT_PEPTIDE_SOURCE_DELIMITER
@@ -170,27 +176,67 @@ class PeptidePoolSplitter():
                 wildcard_map=wildcard_map
             )
             peptide_infos.sort()
-
-            peptide.description = delimiter.join([str(x) for x in peptide_infos])
-            peptide.id = peptide.description
-            peptide.name = peptide.description
-
-            sources = peptide_infos[0].sources
-
-            if len(sources) <= max_groups:
-                database_key = str(sources)
-                self.add_peptide_to_database(database_key, peptide)
+            if split_mode == 'entry':
+                self.add_peptide_to_database_entry_mode(
+                    peptide=peptide,
+                    peptide_infos=peptide_infos,
+                    max_groups=max_groups,
+                    additional_split=additional_split
+                )
             else:
-                has_additional_splitting = False
-                for additional_set in additional_split:
-                    if additional_set.issubset(sources):
-                        database_key = self.get_additional_database_key(additional_set)
-                        self.add_peptide_to_database(database_key, peptide)
-                        has_additional_splitting = True
-                        break
-                if not has_additional_splitting:
-                    database_key = self.get_remaining_database_key()
-                    self.add_peptide_to_database(database_key, peptide)
+                self.add_peptide_to_database_peptide_mode(
+                    peptide=peptide,
+                    peptide_infos=peptide_infos,
+                    delimiter=delimiter,
+                    max_groups=max_groups,
+                    additional_split=additional_split
+                )
+
+    def add_peptide_to_database_peptide_mode(self, peptide:AminoAcidSeqRecord,
+            peptide_infos:List[VariantPeptideInfo], delimiter:str, max_groups:int,
+            additional_split:List[VariantSourceSet]) -> None:
+        """Assign one peptide sequence to exactly one database tier."""
+        peptide.description = delimiter.join([str(x) for x in peptide_infos])
+        peptide.id = peptide.description
+        peptide.name = peptide.description
+
+        database_key = self.get_database_key(
+            sources=peptide_infos[0].sources,
+            max_groups=max_groups,
+            additional_split=additional_split
+        )
+        self.add_peptide_to_database(database_key, peptide)
+
+    def add_peptide_to_database_entry_mode(self, peptide:AminoAcidSeqRecord,
+            peptide_infos:List[VariantPeptideInfo], max_groups:int,
+            additional_split:List[VariantSourceSet]) -> None:
+        """Assign each header entry of a peptide sequence to its own tier."""
+        for peptide_info in peptide_infos:
+            database_key = self.get_database_key(
+                sources=peptide_info.sources,
+                max_groups=max_groups,
+                additional_split=additional_split
+            )
+            entry_peptide = copy.copy(peptide)
+            entry_peptide.description = str(peptide_info)
+            entry_peptide.id = entry_peptide.description
+            entry_peptide.name = entry_peptide.description
+            if database_key not in self.databases:
+                self.databases[database_key] = VariantPeptidePool()
+            # Keep all entry labels for identical peptide sequences.
+            self.databases[database_key].add_peptide(
+                entry_peptide, None, skip_checking=True
+            )
+
+    def get_database_key(self, sources:VariantSourceSet, max_groups:int,
+            additional_split:List[VariantSourceSet]) -> str:
+        """Resolve output database key for a source set."""
+        if len(sources) <= max_groups:
+            return str(sources)
+        for additional_set in additional_split:
+            if additional_set.issubset(sources):
+                return self.get_additional_database_key(additional_set)
+        return self.get_remaining_database_key()
 
     @staticmethod
     def get_additional_database_key(additional:str) -> str:

--- a/moPepGen/cli/split_fasta.py
+++ b/moPepGen/cli/split_fasta.py
@@ -64,6 +64,16 @@ def add_subparser_split_fasta(subparser:argparse._SubParsersAction):
         metavar = '<value>'
     )
     p.add_argument(
+        '--split-mode',
+        type=str,
+        choices=['peptide', 'entry'],
+        default='peptide',
+        help='How to split peptide records. "peptide" keeps current behavior'
+        ' (one assignment per peptide sequence). "entry" splits by individual'
+        ' FASTA header entry.',
+        metavar='<value>'
+    )
+    p.add_argument(
         '--order-source',
         type=str,
         help='Order of sources, separate by comma (e.g., SNP,SNV,Fusion). Whildcard'
@@ -204,7 +214,8 @@ def split_fasta(args:argparse.Namespace) -> None:
         max_groups=args.max_source_groups,
         additional_split=additional_split,
         tx2gene=tx2gene,
-        coding_tx=coding_tx
+        coding_tx=coding_tx,
+        split_mode=getattr(args, 'split_mode', 'peptide')
     )
 
     logger.info('Database split finished')

--- a/moPepGen/cli/split_fasta.py
+++ b/moPepGen/cli/split_fasta.py
@@ -215,7 +215,7 @@ def split_fasta(args:argparse.Namespace) -> None:
         additional_split=additional_split,
         tx2gene=tx2gene,
         coding_tx=coding_tx,
-        split_mode=getattr(args, 'split_mode', 'peptide')
+        split_mode=args.split_mode
     )
 
     logger.info('Database split finished')

--- a/moPepGen/cli/split_fasta.py
+++ b/moPepGen/cli/split_fasta.py
@@ -71,7 +71,7 @@ def add_subparser_split_fasta(subparser:argparse._SubParsersAction):
         help='How to split peptide records. "peptide" keeps current behavior'
         ' (one assignment per peptide sequence). "entry" splits by individual'
         ' FASTA header entry.',
-        metavar='<value>'
+        metavar='<choice>'
     )
     p.add_argument(
         '--order-source',

--- a/test/integration/test_split_fasta.py
+++ b/test/integration/test_split_fasta.py
@@ -35,6 +35,7 @@ class TestSplitDatabase(TestCaseIntegration):
         """ Create base args """
         args = argparse.Namespace()
         args.command = 'splitFasta'
+        args.split_mode = 'peptide'
         args.novel_orf_peptides = None
         args.order_source = None
         args.group_source = None
@@ -226,6 +227,41 @@ class TestSplitDatabase(TestCaseIntegration):
         expected = {
             'test_NovelORF.fasta', 'test_SECT.fasta',
             'test_Remaining.fasta', 'test_CodonReassign.fasta'
+        }
+        self.assertEqual(files, expected)
+
+    def test_split_fasta_entry_mode_splits_shared_headers(self):
+        """split-mode entry should route each header entry to its own tier."""
+        args = self.create_base_args()
+        args.gvf = [
+            self.data_dir/'reditools/reditools.gvf',
+            self.data_dir/'circRNA/circ_rna.gvf'
+        ]
+        args.variant_peptides = self.work_dir/'entry_mode_input.fasta'
+        args.novel_orf_peptides = None
+        args.alt_translation_peptides = None
+        args.annotation_gtf = self.data_dir/'annotation.gtf'
+        args.proteome_fasta = self.data_dir/'translate.fasta'
+        args.split_mode = 'entry'
+        args.max_source_groups = 2
+        args.order_source = 'RNAEditingSite,NovelORF,NovelORF-CodonReassign,circRNA'
+        record = (
+            '>ENST00000614167.2|RES-101-A-G|1 '
+            'ENST00000624155.2|ORF-24:141|1 '
+            'ENST00000624155.2|ORF-24:141|W2F-11|1 '
+            'CIRC-ENST00000614167.2-0:464|ORF-209:5:1|1\n'
+            'PEPTIDE\n'
+        )
+        args.variant_peptides.write_text(record)
+
+        cli.split_fasta(args)
+        files = {str(file.name) for file in self.work_dir.glob('*')}
+        expected = {
+            'test_RNAEditingSite.fasta',
+            'test_NovelORF.fasta',
+            'test_NovelORF-CodonReassign.fasta',
+            'test_circRNA.fasta',
+            'entry_mode_input.fasta'
         }
         self.assertEqual(files, expected)
 

--- a/test/unit/test_peptide_pool_splitter.py
+++ b/test/unit/test_peptide_pool_splitter.py
@@ -674,3 +674,94 @@ class TestPeptidePoolSplitter(unittest.TestCase):
         splitter = PeptidePoolSplitter(peptides=peptides, order=order, label_map=label_map)
         splitter.split(2, [], tx2gene, coding_tx)
         self.assertEqual({'altSplice-NovelORF'}, set(splitter.databases.keys()))
+
+    def test_split_database_entry_mode_splits_shared_headers(self):
+        """Entry mode should split one shared peptide into per-entry tiers."""
+        anno = create_genomic_annotation(ANNOTATION_DATA)
+        anno.transcripts['ENST0005'] = copy.deepcopy(anno.transcripts['ENST0002'])
+        anno.transcripts['ENST0005'].is_protein_coding = False
+        tx2gene, coding_tx = get_tx2gene_and_coding_tx(anno)
+        peptides_data = [[
+            'SSSSSSSR',
+            'ENST0001|SNV-1001-T-A|INDEL-1101-TTTT-T|1 '
+            'ENST0005|ORF-10:100|1 '
+            'ENST0005|ORF-20:110|SNV-2001-T-A|2 '
+            'CIRC-ENST0002-E1-E2|ORF-50:25:1|3'
+        ]]
+        peptides = VariantPeptidePool({create_aa_record(*x) for x in peptides_data})
+        label_map = LabelSourceMapping(copy.copy(LABEL_MAP1))
+        order = {
+            'Variant': 0,
+            'NovelORF': 1,
+            frozenset(['NovelORF', 'Variant']): 2,
+            'circRNA': 3
+        }
+        group_map = {
+            'gSNP': 'Variant',
+            'gINDEL': 'Variant',
+            'sSNV': 'Variant',
+            'sINDEL': 'Variant'
+        }
+        splitter = PeptidePoolSplitter(
+            peptides=peptides,
+            order=order,
+            label_map=label_map,
+            group_map=group_map
+        )
+        splitter.split(2, [], tx2gene, coding_tx, split_mode='entry')
+
+        self.assertEqual(
+            {'Variant', 'NovelORF', 'Variant-NovelORF', 'circRNA'},
+            set(splitter.databases.keys())
+        )
+
+        expected_headers = {
+            'Variant': 'ENST0001|SNV-1001-T-A|INDEL-1101-TTTT-T|1',
+            'NovelORF': 'ENST0005|ORF-10:100|1',
+            'Variant-NovelORF': 'ENST0005|ORF-20:110|SNV-2001-T-A|2',
+            'circRNA': 'CIRC-ENST0002-E1-E2|ORF-50:25:1|3'
+        }
+        for key, header in expected_headers.items():
+            peptide = list(splitter.databases[key].peptides)[0]
+            self.assertEqual(str(peptide.seq), 'SSSSSSSR')
+            self.assertEqual(peptide.description, header)
+
+    def test_split_database_peptide_mode_keeps_single_assignment(self):
+        """Peptide mode should keep one-assignment behavior for shared headers."""
+        anno = create_genomic_annotation(ANNOTATION_DATA)
+        anno.transcripts['ENST0005'] = copy.deepcopy(anno.transcripts['ENST0002'])
+        anno.transcripts['ENST0005'].is_protein_coding = False
+        tx2gene, coding_tx = get_tx2gene_and_coding_tx(anno)
+        peptides_data = [[
+            'SSSSSSSR',
+            'ENST0001|SNV-1001-T-A|INDEL-1101-TTTT-T|1 '
+            'ENST0005|ORF-10:100|1 '
+            'ENST0005|ORF-20:110|SNV-2001-T-A|2 '
+            'CIRC-ENST0002-E1-E2|ORF-50:25:1|3'
+        ]]
+        peptides = VariantPeptidePool({create_aa_record(*x) for x in peptides_data})
+        label_map = LabelSourceMapping(copy.copy(LABEL_MAP1))
+        order = {
+            'Variant': 0,
+            'NovelORF': 1,
+            frozenset(['NovelORF', 'Variant']): 2,
+            'circRNA': 3
+        }
+        group_map = {
+            'gSNP': 'Variant',
+            'gINDEL': 'Variant',
+            'sSNV': 'Variant',
+            'sINDEL': 'Variant'
+        }
+        splitter = PeptidePoolSplitter(
+            peptides=peptides,
+            order=order,
+            label_map=label_map,
+            group_map=group_map
+        )
+        splitter.split(2, [], tx2gene, coding_tx, split_mode='peptide')
+
+        self.assertEqual({'Variant'}, set(splitter.databases.keys()))
+        peptide = list(splitter.databases['Variant'].peptides)[0]
+        self.assertEqual(str(peptide.seq), 'SSSSSSSR')
+        self.assertIn('ENST0001|SNV-1001-T-A|INDEL-1101-TTTT-T|1', peptide.description)


### PR DESCRIPTION
## Description

Add `--split-mode` to `splitFasta` with two modes:
- peptide (default): existing behavior, one tier per peptide sequence
- entry: split by individual FASTA header entry, so shared peptides can appear in multiple tiers

<!--- Briefly describe the changes included in this pull request  --->

Closes #17   <!-- edit if this PR closes an Issue -->

## Checklist
<!--- Please read each of the following items and confirm by replacing the [ ] with a [X] --->

- [X] This PR does NOT contain [PHI](https://ohrpp.research.ucla.edu/hipaa/) or germline genetic data.  A repo may need to be deleted if such data is uploaded. Disclosing PHI is a [major problem](https://healthitsecurity.com/news/ucla-health-reaches-7.5m-settlement-over-2015-breach-of-4.5m).
- [X] This PR does NOT contain molecular files, compressed files, output files such as images (*e.g.* `.png`, .`jpeg`), `.pdf`, `.RData`, `.xlsx`, `.doc`, `.ppt`, or other non-plain-text files.  To automatically exclude such files using a [.gitignore](https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files) file, see [here](https://github.com/uclahs-cds/template-base/blob/main/.gitignore) for example.
- [X] I have read the [code review guidelines](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3187646/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List).
- [X] The name of the branch is meaningful and well formatted following the [standards](https://uclahs-cds.atlassian.net/wiki/spaces/BOUTROSLAB/pages/3189956/Code+Review+Best+Practice+on+GitHub+-+Check+List), using [AD_username (or 5 letters of AD if AD is too long)]-[brief_description_of_branch].
- [X] I have added the major changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.
- [X] All test cases passed locally.
